### PR TITLE
fix: корректное владение HGLOBAL после SetClipboardData

### DIFF
--- a/src/ClipboardManager.cpp
+++ b/src/ClipboardManager.cpp
@@ -121,14 +121,18 @@ bool BaseHelper::ClipboardManager::SetText(const std::wstring& text, bool bEmpty
 	if (!m_isOpened) return false;
 	if (bEmpty) EmptyClipboard();
 	size_t size = (text.size() + 1) * sizeof(wchar_t);
-	if (HGLOBAL hGlobal = GlobalAlloc(GMEM_MOVEABLE, size)) {
-		memcpy(GlobalLock(hGlobal), text.c_str(), size);
-		GlobalUnlock(hGlobal);
-		SetClipboardData(CF_UNICODETEXT, hGlobal);
+	HGLOBAL hGlobal = GlobalAlloc(GMEM_MOVEABLE, size);
+	if (!hGlobal) return false;
+	memcpy(GlobalLock(hGlobal), text.c_str(), size);
+	GlobalUnlock(hGlobal);
+	// After a successful SetClipboardData the system owns hGlobal and will
+	// GlobalFree it itself; freeing here would cause a double-free. Free
+	// only on failure, when ownership was not transferred.
+	if (SetClipboardData(CF_UNICODETEXT, hGlobal) == NULL) {
 		GlobalFree(hGlobal);
-		return true;
+		return false;
 	}
-	else return false;
+	return true;
 }
 
 #include <shlobj.h> // DROPFILES
@@ -203,14 +207,15 @@ bool BaseHelper::ClipboardManager::SetImage(VH& variant, bool bEmpty)
 	std::vector<BYTE> vec;
 	if (image.Save(vec)) {
 		static UINT CF_PNG = RegisterClipboardFormat(L"PNG");
-		if (auto hGlobal = GlobalAlloc(GMEM_MOVEABLE, vec.size())) {
-			auto buffer = (BYTE*)GlobalLock(hGlobal);
-			memcpy(buffer, vec.data(), vec.size());
-			SetClipboardData(CF_PNG, hGlobal);
-			GlobalUnlock(hGlobal);
+		auto hGlobal = GlobalAlloc(GMEM_MOVEABLE, vec.size());
+		if (!hGlobal) return false;
+		auto buffer = (BYTE*)GlobalLock(hGlobal);
+		memcpy(buffer, vec.data(), vec.size());
+		GlobalUnlock(hGlobal);
+		if (SetClipboardData(CF_PNG, hGlobal) == NULL) {
 			GlobalFree(hGlobal);
+			return false;
 		}
-		else return false;
 	}
 	else return false;
 
@@ -225,15 +230,17 @@ bool BaseHelper::ClipboardManager::SetImage(VH& variant, bool bEmpty)
 		ReleaseDC(NULL, hDC);
 		DeleteObject(hBitmap);
 
-		if (auto hGlobal = GlobalAlloc(GMEM_MOVEABLE, sizeof bi + vec.size())) {
-			auto buffer = (BYTE*)GlobalLock(hGlobal);
-			memcpy(buffer, &bi, sizeof bi);
-			memcpy(buffer + sizeof bi, vec.data(), vec.size());
-			SetClipboardData(CF_DIB, hGlobal);
-			GlobalUnlock(hGlobal);
+		auto hGlobal = GlobalAlloc(GMEM_MOVEABLE, sizeof bi + vec.size());
+		if (!hGlobal) return false;
+		auto buffer = (BYTE*)GlobalLock(hGlobal);
+		memcpy(buffer, &bi, sizeof bi);
+		memcpy(buffer + sizeof bi, vec.data(), vec.size());
+		GlobalUnlock(hGlobal);
+		if (SetClipboardData(CF_DIB, hGlobal) == NULL) {
 			GlobalFree(hGlobal);
-			return true;
+			return false;
 		}
+		return true;
 	}
 	return false;
 }


### PR DESCRIPTION
## Что не так

[Issue #84](https://github.com/lintest/VanessaExt/issues/84) — при чередовании `ВнешняяКомпонента.ЗаписатьТекст(...)` и ручного `Ctrl+C` с последующим `Ctrl+V` в буфер обмена попадает «какая-то ерунда» (типично — строки вида `୘^`). Стабильно воспроизводится у нескольких пользователей (@Diversus23, @Pr-Mex).

## Корневая причина

`ClipboardManager.cpp` вызывает `GlobalFree(hGlobal)` сразу после `SetClipboardData(...)`. Это нарушает контракт Win API: после успешного `SetClipboardData` владение HGLOBAL переходит к системе, и приложение не должно его освобождать.
> «If SetClipboardData succeeds, the system owns the object identified by the hMem parameter. The application **may not write to or free the data** once ownership has been transferred to the system…»
> — [MSDN: SetClipboardData](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setclipboarddata)

Для `CF_UNICODETEXT`, `CF_DIB` и HGLOBAL-based custom-форматов (включая используемый здесь `CF_PNG`) система **сама** вызывает `GlobalFree` при следующем `EmptyClipboard` — см. таблицу [Memory and the 
Clipboard](https://learn.microsoft.com/en-us/windows/win32/dataxchg/clipboard-operations#memory-and-the-clipboard).

В итоге наш `GlobalFree` создаёт double-free: heap-блок освобождается дважды (нами и системой), при этом адрес ещё ассоциирован с буфером обмена → use-after-free при `Ctrl+V`. Современный Low Fragmentation Heap часто маскирует креш, отдавая чужие байты, которые UTF-16-декодер показывает как мусорные иероглифы (`୘` = U+0B58 + случайный байт = типичный «random UTF-16»).