### PR TITLE
fix: утечка HBITMAP в ScreenManager::Capture

### DIFF
--- a/src/ScreenManager.cpp
+++ b/src/ScreenManager.cpp
@@ -163,11 +163,15 @@ BOOL BaseHelper::ScreenManager::Capture(VH variant, HWND window)
 	HDC hdcScreen = GetDC(NULL);
 	HDC hDC = CreateCompatibleDC(hdcScreen);
 	HBITMAP hBitmap = CreateCompatibleBitmap(hdcScreen, rc.right - rc.left, rc.bottom - rc.top);
-	SelectObject(hDC, hBitmap);
+	// Save the default object so we can restore it before DeleteDC; otherwise
+	// DeleteObject(hBitmap) silently fails because the bitmap is still selected
+	// into hDC, leaking the HBITMAP (1 GDI handle per call).
+	HGDIOBJ object = SelectObject(hDC, hBitmap);
 	::PrintWindow(hWnd, hDC, PW_CLIENTONLY | PW_RENDERFULLCONTENT);
 	ImageHelper(hBitmap).Save(variant);
-	ReleaseDC(NULL, hdcScreen);
+	SelectObject(hDC, object);
 	DeleteDC(hDC);
+	ReleaseDC(NULL, hdcScreen);
 	DeleteObject(hBitmap);
 	return true;
 }


### PR DESCRIPTION
## Что не так

В функции `ScreenManager::Capture` (`src/ScreenManager.cpp:152`) не сохранялся default-объект DC перед `SelectObject(hDC, hBitmap)`. На выходе:
- `DeleteDC(hDC)` вызывается, пока `hBitmap` всё ещё selected.
- `DeleteObject(hBitmap)` молча возвращает `0` и **не освобождает GDI handle**.

> «Do not delete a drawing object (pen or brush) while it is still selected into a DC.»
> — [MSDN: DeleteObject](https://learn.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-deleteobject)

Каждый вызов `Capture` оставляет 1 неосвобождённый HBITMAP.

## Кого затрагивает

`Capture` вызывается из:
- `CaptureWindow(variant, window)` → шаг `СделатьСкриншотОкна`
- `CaptureScreen(variant, mode)` при `mode != 0` → скриншот foreground-окна
