### PR TITLE
fix: утечки SAFEARRAY/BSTR/VARIANT в ProcessEnumerator

### DIFF
--- a/src/ProcessManager.cpp
+++ b/src/ProcessManager.cpp
@@ -111,13 +111,17 @@ public:
 							break;
 						default:
 							VARIANTARG vtDest;
+							VariantInit(&vtDest);
 							hr = VariantChangeType(&vtDest, &vtProp, VARIANT_ALPHABOOL, VT_BSTR);
 							if SUCCEEDED(hr) json[WC2MB(name)] = WC2MB(vtDest.bstrVal);
+							VariantClear(&vtDest);
 						}
 					}
 				}
 				VariantClear(&vtProp);
+				SysFreeString(name);
 			}
+			SafeArrayDestroy(pNames);
 			result.push_back(json);
 			pclsObj->Release();
 			pclsObj = NULL;


### PR DESCRIPTION
## Что не так

В цикле перебора WMI-результатов внутри `ProcessEnumerator` (`src/ProcessManager.cpp`) не освобождались четыре вида ресурсов:

1. **`SAFEARRAY* pNames`** от `IWbemClassObject::GetNames` — никогда не вызывался `SafeArrayDestroy`.
2. **`BSTR name`** от `SafeArrayGetElement` — для массивов VT_BSTR функция копирует строку, владение переходит вызывающему. `SysFreeString` не вызывался.
3. **`VARIANTARG vtDest`** после `VariantChangeType(..., VT_BSTR)` — новый BSTR в `vtDest.bstrVal` оставался непосвобождённым (`VariantClear` не вызывался).
4. **`vtDest` не инициализировался** через `VariantInit` перед `VariantChangeType` — formally UB по контракту OLE Automation.

> «The caller must call **SafeArrayDestroy** on the returned safearray when it is no longer required.»  
> — [MSDN: IWbemClassObject::GetNames](https://learn.microsoft.com/en-us/windows/win32/api/wbemcli/nf-wbemcli-iwbemclassobject-getnames)

> «On entry, the variant referenced by `pvargDest` must be initialized to either VT_EMPTY or any valid VARIANT type.»  
> — [MSDN: VariantChangeType](https://learn.microsoft.com/en-us/windows/win32/api/oleauto/nf-oleauto-variantchangetype)

## Кого затрагивает

`ProcessEnumerator` — фундамент всех WMI-запросов в компоненте. Вызывается из:

- `FindTestClient(...)` — поиск окна тестируемого 1С (частый, обычно много раз за сессию VA)
- `GetProcessList(...)` — `СписокПроцессов` 
- `FindProcess(...)` — поиск процесса по имени
- `GetProcessInfo(...)` — мониторинг памяти (#81)
- `ParentProcessId(...)` — в составе `ConsoleOut`