### PR TITLE
fix: утечки std::string и thread handle в GherkinParser

### DIFF
--- a/src/GherkinParser.cpp
+++ b/src/GherkinParser.cpp
@@ -126,8 +126,10 @@ static LRESULT CALLBACK MonitorWndProc(HWND hWnd, UINT message, WPARAM wParam, L
 	{
 	case WM_PARSING_PROGRESS:
 	case WM_PARSING_FINISHED: {
+		// Sender allocates std::string with `new`; take ownership here to avoid leak.
+		std::unique_ptr<std::string> data((std::string*)lParam);
 		auto component = (GherkinParser*)GetWindowLongPtr(hWnd, GWLP_USERDATA);
-		if (component) component->OnProgress(message, *(std::string*)lParam);
+		if (component) component->OnProgress(message, *data);
 		return 0;
 	}
 	default:
@@ -171,7 +173,9 @@ void GherkinParser::OnProgress(UINT id, const std::string& data)
 void GherkinParser::ScanFolder(const std::string& dirs, const std::string& libs, const std::string& filter)
 {
 	auto progress = new GherkinProgress(*provider, dirs, libs, filter, hWndMonitor);
-	CreateThread(0, NULL, ParserThreadProc, (LPVOID)progress, NULL, NULL);
+	HANDLE hThread = CreateThread(0, NULL, ParserThreadProc, (LPVOID)progress, NULL, NULL);
+	if (hThread) CloseHandle(hThread);
+	else delete progress;
 }
 
 void GherkinParser::AbortScan()


### PR DESCRIPTION
## Проблема

`GherkinParser::ScanFolder` → `GherkinProgress::Send` / `Scan` отправляют `std::string*` через `SendMessageW(lParam)`. `MonitorWndProc` разыменовывает указатель и не освобождает — утечка на каждый `WM_PARSING_PROGRESS` (один на `.feature` файл) и финальный `WM_PARSING_FINISHED` с полным JSON результата.

Дополнительно: HANDLE от `CreateThread` отбрасывается. Per MSDN: «The thread object remains in the system until the thread has terminated **and all handles to it have been closed**.»

## Фикс

- `MonitorWndProc`: `std::unique_ptr<std::string>` забирает владение из `lParam`. `SendMessage` синхронен — sender безопасно теряет указатель.
- `ScanFolder`: `CloseHandle` сразу после успешного `CreateThread`. На отказ — `delete progress`.

## Ссылки

- [MSDN: SendMessageW](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-sendmessagew)
- [MSDN: CreateThread](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createthread)