### PR TITLE
fix: утечки thread handle во всех fire-and-forget CreateThread

### DIFF
--- a/src/ClickEffect.cpp
+++ b/src/ClickEffect.cpp
@@ -232,7 +232,9 @@ namespace ClickEffect {
 	LRESULT Hooker::Show()
 	{
 		auto painter = new Painter(*this);
-		CreateThread(0, NULL, EffectThreadProc, (LPVOID)painter, NULL, NULL);
+		HANDLE h = CreateThread(0, NULL, EffectThreadProc, (LPVOID)painter, NULL, NULL);
+		if (h) CloseHandle(h);
+		else delete painter;
 		return 0L;
 	}
 
@@ -271,7 +273,9 @@ namespace ClickEffect {
 	void Show(int64_t color, int64_t radius, int64_t width, int64_t delay, int64_t trans, int64_t echo)
 	{
 		auto painter = new Painter(Hooker(color, radius, width, delay, trans, echo));
-		CreateThread(0, NULL, EffectThreadProc, (LPVOID)painter, NULL, NULL);
+		HANDLE h = CreateThread(0, NULL, EffectThreadProc, (LPVOID)painter, NULL, NULL);
+		if (h) CloseHandle(h);
+		else delete painter;
 	}
 
 	typedef void(__cdecl* StartHookProc)(int64_t color, int64_t radius, int64_t width, int64_t delay, int64_t trans, int64_t echo);
@@ -332,7 +336,9 @@ extern "C" {
 	{
 		StopClickEffect();
 		Hooker* settings = new Hooker(color, radius, width, delay, trans, echo);
-		CreateThread(0, NULL, HookerThreadProc, (LPVOID)settings, NULL, NULL);
+		HANDLE h = CreateThread(0, NULL, HookerThreadProc, (LPVOID)settings, NULL, NULL);
+		if (h) CloseHandle(h);
+		else delete settings;
 	}
 }
 

--- a/src/EducationShow.cpp
+++ b/src/EducationShow.cpp
@@ -355,7 +355,9 @@ void EducationShow::run()
 {
 	close();
 	sm_stop = false;
-	CreateThread(0, NULL, PainterThreadProc, (LPVOID)this, NULL, NULL);
+	HANDLE h = CreateThread(0, NULL, PainterThreadProc, (LPVOID)this, NULL, NULL);
+	if (h) CloseHandle(h);
+	else delete this;
 }
 
 #endif //_WINDOWS

--- a/src/EventMonitor.cpp
+++ b/src/EventMonitor.cpp
@@ -182,7 +182,9 @@ extern "C" {
 		if (hMouseHook) UnhookWindowsHookEx(hMouseHook);
 		if (addin) {
 			Hooker* settings = new Hooker((AddInNative*)addin);
-			CreateThread(0, NULL, HookerThreadProc, (LPVOID)settings, NULL, NULL);
+			HANDLE h = CreateThread(0, NULL, HookerThreadProc, (LPVOID)settings, NULL, NULL);
+			if (h) CloseHandle(h);
+			else delete settings;
 		}
 	}
 }

--- a/src/Magnifier.cpp
+++ b/src/Magnifier.cpp
@@ -132,7 +132,9 @@ void Magnifier::Show(int x, int y, int w, int h, double z, int f)
 {
 	Hide();
 	auto data = new MagnifierData(x, y, w, h, (float)z, f);
-	CreateThread(0, NULL, MagnifierThreadProc, (LPVOID)data, NULL, NULL);
+	HANDLE h = CreateThread(0, NULL, MagnifierThreadProc, (LPVOID)data, NULL, NULL);
+	if (h) CloseHandle(h);
+	else delete data;
 }
 
 void Magnifier::Hide()

--- a/src/SoundEffect.cpp
+++ b/src/SoundEffect.cpp
@@ -134,7 +134,9 @@ void SoundEffect::PlayMedia(AddInNative& addin, const std::wstring& filename, co
 {
 	if (!uuid.empty()) StopMedia(uuid);
 	auto params = new SoundHandler(addin, uuid, filename);
-	CreateThread(0, NULL, EffectThreadProc, (LPVOID)params, NULL, NULL);
+	HANDLE h = CreateThread(0, NULL, EffectThreadProc, (LPVOID)params, NULL, NULL);
+	if (h) CloseHandle(h);
+	else delete params;
 }
 
 void SoundEffect::StopMedia(const std::wstring& uuid)

--- a/src/VideoPainter.cpp
+++ b/src/VideoPainter.cpp
@@ -942,7 +942,9 @@ static DWORD WINAPI PainterThreadProc(LPVOID lpParam)
 
 void PainterBase::run()
 {
-	CreateThread(0, NULL, PainterThreadProc, (LPVOID)this, NULL, NULL);
+	HANDLE h = CreateThread(0, NULL, PainterThreadProc, (LPVOID)this, NULL, NULL);
+	if (h) CloseHandle(h);
+	else delete this;
 }
 
 #endif //_WINDOWS

--- a/src/WindowsControl.cpp
+++ b/src/WindowsControl.cpp
@@ -493,7 +493,15 @@ int64_t WindowsControl::LaunchProcess(const std::wstring& command, bool hide)
 	auto ok = CreateProcess(NULL, (LPWSTR)command.c_str(), NULL, NULL, TRUE, CREATE_NEW_CONSOLE, NULL, NULL, &si, pi);
 	if (ok) {
 		pid = (int64_t)pi->dwProcessId;
-		CreateThread(0, NULL, ProcessThreadProc, (LPVOID)pi, NULL, NULL);
+		HANDLE h = CreateThread(0, NULL, ProcessThreadProc, (LPVOID)pi, NULL, NULL);
+		if (h) {
+			CloseHandle(h);
+		}
+		else {
+			CloseHandle(pi->hProcess);
+			CloseHandle(pi->hThread);
+			delete pi;
+		}
 	}
 	else {
 		delete pi;


### PR DESCRIPTION
## Проблема

В 9 сайтах `CreateThread` возвращаемый HANDLE отбрасывался. Per MSDN: «The thread object remains in the system until the thread has terminated **and all handles to it have been closed**.» Kernel-объект потока висит до закрытия процесса — +1 handle на каждый вызов.

## Сайты

| Файл | Триггер в VA |
|---|---|
| `ClickEffect.cpp` (×3) | per-click effect, manual Show, hook startup |
| `VideoPainter.cpp` | все painters (Rectangle/Ellipse/Arrow/Shadow/SpeechBubble/...) |
| `EducationShow.cpp` | training instruction |
| `SoundEffect.cpp` | per-sound |
| `Magnifier.cpp` | per-zoom |
| `EventMonitor.cpp` | click hook startup |
| `WindowsControl.cpp` | `LaunchProcess` |

Самые горячие — `ClickEffect.cpp` (на каждый клик при включённом эффекте) и `VideoPainter` (на каждое визуальное выделение элемента).

## Фикс

Везде идентичный паттерн:
```cpp
HANDLE h = CreateThread(0, NULL, ThreadProc, (LPVOID)x, NULL, NULL);
if (h) CloseHandle(h);
else delete x;
```

CloseHandle сразу после успешного CreateThread — документированный fire-and-forget. Поток держит self-reference и продолжает выполнение. На отказ — освобождается объект, который должен был забрать ThreadProc.

Для LaunchProcess дополнительно закрываются pi->hProcess и pi->hThread от CreateProcess на отказ (caller обязан их закрыть).

Ссылки

- MSDN: CreateThread (https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createthread)