### PR TITLE
TASK-206: скриншоты в Xvfb без window manager

### DIFF
--- a/src/ScreenManager.cpp
+++ b/src/ScreenManager.cpp
@@ -364,6 +364,56 @@ BOOL BaseHelper::ScreenManager::EmulateText(const std::wstring& text, int64_t pa
 #include <X11/extensions/XTest.h>
 #include <unistd.h>
 
+static bool HasWindowManager(Display* display)
+{
+	if (!display) return false;
+
+	Window root = DefaultRootWindow(display);
+	Atom property = XInternAtom(display, "_NET_SUPPORTING_WM_CHECK", False);
+	Atom actual_type = None;
+	int actual_format = 0;
+	unsigned long item_count = 0;
+	unsigned long bytes_after = 0;
+	unsigned char* data = NULL;
+
+	int result = XGetWindowProperty(
+		display,
+		root,
+		property,
+		0,
+		1,
+		False,
+		XA_WINDOW,
+		&actual_type,
+		&actual_format,
+		&item_count,
+		&bytes_after,
+		&data);
+
+	if (data) XFree(data);
+	return result == Success && actual_type == XA_WINDOW && actual_format == 32 && item_count > 0;
+}
+
+static void PrepareWindowForCapture(Display* display, Window window, XWindowAttributes& attributes)
+{
+	if (!display || !window || window == DefaultRootWindow(display)) return;
+
+	if (HasWindowManager(display)) return;
+
+	unsigned int width = attributes.width > 0 ? (unsigned int)attributes.width : 1200;
+	unsigned int height = attributes.height > 0 ? (unsigned int)attributes.height : 800;
+
+	if (width > 1200) width = 1200;
+	if (height > 800) height = 800;
+
+	XMapRaised(display, window);
+	XMoveResizeWindow(display, window, 0, 0, width, height);
+
+	XFlush(display);
+	usleep(200000);
+	XGetWindowAttributes(display, window, &attributes);
+}
+
 class ScreenEnumerator : public WindowHelper
 {
 public:
@@ -489,10 +539,14 @@ BOOL BaseHelper::ScreenManager::Capture(VH variant, Window window)
 	if (display == nullptr) return false;
 	if (window == 0) window = DefaultRootWindow(display);
 	XWindowAttributes gwa;
-	if (XGetWindowAttributes(display, window, &gwa) == 0) return false;
+	if (XGetWindowAttributes(display, window, &gwa) == 0) {
+		XCloseDisplay(display);
+		return false;
+	}
+	PrepareWindowForCapture(display, window, gwa);
 	XImage* image = XGetImage(display, window, 0, 0, gwa.width, gwa.height, AllPlanes, ZPixmap);
 	auto success = image && Save(image, variant, gwa.width, gwa.height);
-	XDestroyImage(image);
+	if (image) XDestroyImage(image);
 	XCloseDisplay(display);
 	return success;
 }

--- a/src/WindowsManager.cpp
+++ b/src/WindowsManager.cpp
@@ -313,6 +313,7 @@ protected:
 			j["Types"] = GetWindowTypes(window);
 			j["States"] = GetWindowStates(window);
 			j["VisibleName"] = GetVisibleName(window);
+			if (!HasWindowManager()) j["MapState"] = GetMapState(window);
 			j["ProcessId"] = pid;
 			json.push_back(j);
 		}

--- a/src/XWinBase.h
+++ b/src/XWinBase.h
@@ -134,6 +134,33 @@ protected:
         }
     }
 
+    bool HasWindowManager() {
+        Window root = DefaultRootWindow(display);
+        Atom property = XInternAtom(display, "_NET_SUPPORTING_WM_CHECK", False);
+        Atom actual_type = None;
+        int actual_format = 0;
+        unsigned long item_count = 0;
+        unsigned long bytes_after = 0;
+        unsigned char* data = NULL;
+
+        int result = XGetWindowProperty(
+            display,
+            root,
+            property,
+            0,
+            1,
+            False,
+            XA_WINDOW,
+            &actual_type,
+            &actual_format,
+            &item_count,
+            &bytes_after,
+            &data);
+
+        if (data) XFree(data);
+        return result == Success && actual_type == XA_WINDOW && actual_format == 32 && item_count > 0;
+    }
+
     unsigned long GetWindowPid(Window window) {
 		unsigned long size, *pid = NULL;
 		GetProperty(window, XA_CARDINAL, "_NET_WM_PID", VXX(&pid), &size);
@@ -146,6 +173,21 @@ protected:
         Window parent = 0;
         Status status = XGetTransientForHint(display, window, &parent);
         return status ? parent : 0;
+    }
+
+    std::string GetMapState(Window window) {
+        XWindowAttributes attributes;
+        if (!XGetWindowAttributes(display, window, &attributes)) return {};
+        switch (attributes.map_state) {
+            case IsUnmapped:
+                return "IsUnMapped";
+            case IsUnviewable:
+                return "IsUnviewable";
+            case IsViewable:
+                return "IsViewable";
+            default:
+                return {};
+        }
     }
 
     std::string S(char *buffer) {
@@ -284,6 +326,22 @@ class WindowEnumerator : public WindowHelper
 private:
     Window* m_windows = NULL;
     unsigned long m_count = 0;
+    std::vector<Window> m_fallback_windows;
+
+    void CollectTreeWindows(Window parent) {
+        Window root = 0, parent_return = 0;
+        Window* children = NULL;
+        unsigned int count = 0;
+
+        if (!XQueryTree(display, parent, &root, &parent_return, &children, &count)) return;
+
+        for (unsigned int i = 0; i < count; i++) {
+            m_fallback_windows.push_back(children[i]);
+            CollectTreeWindows(children[i]);
+        }
+
+        if (children) XFree(children);
+    }
 
 protected:
     virtual bool EnumWindow(Window window) = 0;
@@ -294,19 +352,29 @@ public:
         if (GetProperty(root, XA_WINDOW, "_NET_CLIENT_LIST", VXX(&m_windows), &m_count)) return;
         if (GetProperty(root, XA_WINDOW, "_WIN_CLIENT_LIST", VXX(&m_windows), &m_count)) return;
         m_count = 0; // Cannot get client list properties.
+        if (!HasWindowManager()) {
+            CollectTreeWindows(root);
+        }
 	    std::wcout << std::endl << "DefaultRootWindow: " << root << std::endl << std::endl;
-	    std::wcout << std::endl << "Window count: " << m_count << std::endl << std::endl;
+	    std::wcout << std::endl << "Window count: " << (m_count > 0 ? m_count : m_fallback_windows.size()) << std::endl << std::endl;
     }
 
     std::string Enumerate() {
-        for (int i = 0; i < m_count; i++) {
-            if (!EnumWindow(m_windows[i])) break;
+        if (m_count > 0) {
+            for (unsigned long i = 0; i < m_count; i++) {
+                if (!EnumWindow(m_windows[i])) break;
+            }
+        }
+        else {
+            for (auto window : m_fallback_windows) {
+                if (!EnumWindow(window)) break;
+            }
         }
         return json.dump();
     }
 
 	virtual ~WindowEnumerator() {
-        XFree(m_windows);
+        if (m_windows) XFree(m_windows);
 	}
 };
 


### PR DESCRIPTION
## Что сделано

- Добавлен fallback перечисления окон через `XQueryTree`, когда root window не содержит `_NET_CLIENT_LIST` / `_WIN_CLIENT_LIST` и в окружении нет window manager.
- `CaptureWindow` в no-WM окружении перед `XGetImage` подготавливает выбранное окно: `XMapRaised`, `XMoveResizeWindow`, `XFlush` и короткая пауза на отрисовку.
- В `GetWindowList` для no-WM режима добавлено диагностическое поле `MapState`, чтобы видеть `IsUnMapped` / `IsUnviewable` / `IsViewable` при разборе окон 1С.

## Почему

В Xvfb без window manager у root window отсутствуют EWMH/client-list свойства, поэтому старый путь перечисления окон не видел нужное окно 1С. Даже при известном handle скриншот мог получаться чёрным, потому что окно не было подготовлено к экспонированию/отрисовке в no-WM окружении.

Новая логика включается только если не найден `_NET_SUPPORTING_WM_CHECK`. В окружении с обычным window manager сохраняется прежний путь работы через client-list свойства и без принудительного map/raise/resize.

## Основные изменённые методы

- `WindowHelper::HasWindowManager` - проверка наличия window manager по `_NET_SUPPORTING_WM_CHECK`.
- `WindowHelper::GetMapState` - диагностическое состояние X11 map state.
- `WindowEnumerator::CollectTreeWindows` / `Enumerate` - fallback обхода дерева окон только для no-WM случая.
- `WindowsManager::GetWindowList` - добавляет `MapState` в JSON только когда нет window manager.
- `ScreenManager::Capture` / `PrepareWindowForCapture` - подготовка выбранного окна перед захватом только в no-WM окружении.

## Совместимость

- Входные параметры методов не изменились.
- Требования к вызовам, настройкам профилей и переменным окружения не изменились.
- Сценарий Vanessa Automation остаётся прежним: `connect_test_client(profileName)`, затем `get_window_list_os`, затем `get_window_screenshot_os(window_title=...)`.
- Имя и версия компоненты в поставке остаются `VanessaExtLin64_1-3-9-131.so`.
- Выходной JSON `GetWindowList` в no-WM режиме получает дополнительное диагностическое поле `MapState`; существующие поля не удалялись и не переименовывались.

## Проверка

- Собрана полноценная Linux x64 компонента с `WITH_BOOST=ON`, `WITH_OPENCV=ON`, `WITH_GHERKIN=ON`.
- После установки `elfutils` бинарник корректно strip-ится: `VanessaExtLin64.so` = 9 613 896 байт; прежняя поставка была 8 697 728 байт.
- Компонента встроена в `WindowCaptureComponent` Vanessa Automation, пользовательский кэш `/home/vscode/.1cv8/1C/1cv8/ExtCompT` очищен, установленная компонента совпала по sha256 с артефактом сборки.
- Проверка выполнялась в Xvfb/no-WM окружении: `_NET_SUPPORTING_WM_CHECK`, `_NET_CLIENT_LIST`, `_WIN_CLIENT_LIST` отсутствуют.
- Через VA MCP: `connect_test_client(profileName="task205-own-demo-48020-48029")`, `get_window_list_os`, `get_window_screenshot_os(window_title="TRADE / Демонстрационная конфигурация ...")`.
- Получен PNG `1200x800`, `nonblack=959886/960000`, что подтверждает отсутствие black screenshot.
